### PR TITLE
🐛 fix: add RWMutex for map current write

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/socket-iox/socket-io-client-go v1.0.3 h1:n9WJvg0JIMAi6JRBxVWt/dwFNq/tDEoArqNhWrUl4jQ=
-github.com/socket-iox/socket-io-client-go v1.0.3/go.mod h1:FwDTCw0W3FRGh7eXoj8Pho6fCSLFtUYvF2UOzcZScgo=
 github.com/socket-iox/socket-io-client-go v1.0.4 h1:i2yahBo8F8/mpK7y8jROBMAu+vdHWZCuDIXI2Qsaizk=
 github.com/socket-iox/socket-io-client-go v1.0.4/go.mod h1:yhSGbNknJXclxQc9hgfRdMsfo8SO2XHSMbZylJeJvTU=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/user_test.go
+++ b/user_test.go
@@ -1,9 +1,9 @@
 package featureprobe
 
 import (
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
 )
 
 func TestFPUser(t *testing.T) {
@@ -17,4 +17,19 @@ func TestFPUser(t *testing.T) {
 func TestAutoGenerateUserKey(t *testing.T) {
 	var user = NewUser()
 	assert.Equal(t, 19, len(user.Key()))
+}
+
+func TestCurrentWriteUserAttr(t *testing.T) {
+	var user = NewUser()
+	var wg sync.WaitGroup
+	wg.Add(10)
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			defer wg.Done()
+			user.With("foo", "bar")
+		}()
+	}
+
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes #17.

Introduced a `RWMutex` for operations on `user.attr`, since typically we care more about the read operation and read more times than write.

#### Benchmarking

Assuming an user holds 50 attr in average, and the freq of r/w=4:
```go
func BenchmarkRWAttr(b *testing.B) {
	u := NewUser()
	for i := 0; i < 50; i++ {
		u.With(strconv.Itoa(i), "")
	}
	b.ResetTimer()
	for n := 0; n < b.N; n++ {
		func() {
			u.With("", "")
			_ = u.Get("")
			_ = u.Get("")
			_ = u.Get("")
			_ = u.Get("")
		}()
	}
}
...
```

```
goos: darwin
goarch: amd64
pkg: github.com/featureprobe/server-sdk-go/v2
cpu: VirtualApple @ 2.50GHz
BenchmarkRawMap
BenchmarkRawMap-8       16775826                70.21 ns/op  <--- before
BenchmarkSyncMap
BenchmarkSyncMap-8       7360030               183.0 ns/op   <--- sync.Map
BenchmarkRWAttr
BenchmarkRWAttr-8       14031879                73.90 ns/op  <--- applied in this pr
```